### PR TITLE
Disable ServiceControl queue validation if no custom checks exist

### DIFF
--- a/src/ServiceControl.Plugin.CustomChecks/CustomChecks.cs
+++ b/src/ServiceControl.Plugin.CustomChecks/CustomChecks.cs
@@ -43,6 +43,11 @@
 
             protected override async Task OnStart(IMessageSession session)
             {
+                if (!customChecks.Any())
+                {
+                    return;
+                }
+
                 timerPeriodicChecks = new List<TimerBasedPeriodicCheck>(customChecks.Count);
                 serviceControlBackend = new ServiceControlBackend(dispatchMessages, settings, criticalError);
                 await serviceControlBackend.VerifyIfServiceControlQueueExists().ConfigureAwait(false);
@@ -58,7 +63,7 @@
 
             protected override Task OnStop(IMessageSession session)
             {
-                return Task.WhenAll(timerPeriodicChecks.Select(t => t.Stop()).ToArray());
+                return customChecks.Any() ? Task.WhenAll(timerPeriodicChecks.Select(t => t.Stop()).ToArray()) : Task.FromResult(0);
             }
 
             readonly CriticalError criticalError;

--- a/src/ServiceControl.Plugin.Nsb6.CustomChecks.AcceptanceTests/ServiceControl.Plugin.Nsb6.CustomChecks.AcceptanceTests.csproj
+++ b/src/ServiceControl.Plugin.Nsb6.CustomChecks.AcceptanceTests/ServiceControl.Plugin.Nsb6.CustomChecks.AcceptanceTests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="EndpointTemplates\EndpointCustomizationConfigurationExtensions.cs" />
     <Compile Include="ReportCustomCheckResult.cs" />
     <Compile Include="ScenarioDescriptors\EnvironmentHelper.cs" />
+    <Compile Include="When_no_custom_checks_exist.cs" />
     <Compile Include="When_registering_custom_check_which_fails.cs" />
     <Compile Include="EndpointTemplates\ConfigureExtensions.cs" />
     <Compile Include="EndpointTemplates\DefaultServer.cs" />
@@ -77,6 +78,7 @@
     <Compile Include="When_registering_custom_check_which_fails_periodically.cs" />
     <Compile Include="When_registering_custom_check_which_succeeds.cs" />
     <Compile Include="When_registering_custom_check_which_succeeds_periodically.cs" />
+    <Compile Include="When_servicecontrol_queue_is_not_set.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">

--- a/src/ServiceControl.Plugin.Nsb6.CustomChecks.AcceptanceTests/When_no_custom_checks_exist.cs
+++ b/src/ServiceControl.Plugin.Nsb6.CustomChecks.AcceptanceTests/When_no_custom_checks_exist.cs
@@ -1,0 +1,46 @@
+﻿namespace ServiceControl.Plugin.Nsb6.CustomChecks.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    class When_no_custom_checks_exist : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task The_endpoint_should_start_normally()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When(ms => ms.SendLocal(new MyMessage())))
+                .Done(c => c.HandlerCalled)
+                .Run();
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool HandlerCalled { get; set; }
+        }
+
+        public class MyMessage : ICommand { }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context TestContext { get; set; }
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    TestContext.HandlerCalled = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.Plugin.Nsb6.CustomChecks.AcceptanceTests/When_servicecontrol_queue_is_not_set.cs
+++ b/src/ServiceControl.Plugin.Nsb6.CustomChecks.AcceptanceTests/When_servicecontrol_queue_is_not_set.cs
@@ -1,0 +1,49 @@
+namespace ServiceControl.Plugin.Nsb6.CustomChecks.AcceptanceTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using ServiceControl.Plugin.CustomChecks;
+
+    class When_servicecontrol_queue_is_not_set : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void The_endpoint_should_not_start_with_custom_checks()
+        {
+            var ex = Assert.ThrowsAsync<AggregateException>(async () => await Scenario.Define<Context>()
+                .WithEndpoint<Sender>()
+                .Run());
+
+            // ReSharper disable once PossibleNullReferenceException
+            Assert.IsTrue(ex.InnerExceptions[0].InnerException.Message.Contains("ServiceControl queue is not specified"));
+        }
+
+        class Context : ScenarioContext
+        {
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        class MyCustomCheck : CustomCheck
+        {
+            public MyCustomCheck()
+                : base("SuccessfulCustomCheck", "CustomCheck")
+            {
+            }
+
+            public override Task<CheckResult> PerformCheck()
+            {
+                return CheckResult.Pass;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Exists OnStart if no custom checks were found, avoiding tear down if the plugin is installed but not used and the ServiceControl address is not defined.
