### PR TITLE
Prevent startup instead of raising a critical error

### DIFF
--- a/src/Shared/ServiceControlBackend.cs
+++ b/src/Shared/ServiceControlBackend.cs
@@ -24,7 +24,6 @@
         public ServiceControlBackend(IDispatchMessages messageSender, ReadOnlySettings settings, CriticalError criticalError)
         {
             this.settings = settings;
-            this.criticalError = criticalError;
             this.messageSender = messageSender;
             serializer = new DataContractJsonSerializer(typeof(ReportCustomCheckResult), new DataContractJsonSerializerSettings
             {
@@ -128,12 +127,11 @@ Please ensure that the Particular ServiceControl queue is specified either via c
                 const string errMsg = @"You have ServiceControl plugins installed in your endpoint, however, this endpoint is unable to contact the ServiceControl Backend to report endpoint information.
 Please ensure that the Particular ServiceControl queue specified is correct.";
 
-                criticalError.Raise(errMsg, ex);
+                throw new Exception(errMsg, ex);
             }
         }
 
         RepeatedFailuresOverTimeCircuitBreaker circuitBreaker;
-        CriticalError criticalError;
         IDispatchMessages messageSender;
         readonly string sendIntent = MessageIntentEnum.Send.ToString();
         DataContractJsonSerializer serializer;


### PR DESCRIPTION
Critical errors shouldn't be raised during startup, as it can cause race conditions between endpoint start and stop.
