### PR TITLE
Typo in error message

### DIFF
--- a/src/Shared/ServiceControlBackend.cs
+++ b/src/Shared/ServiceControlBackend.cs
@@ -104,7 +104,7 @@
             }
 
             const string errMsg = @"You have ServiceControl plugins installed in your endpoint, however, the Particular ServiceControl queue is not specified.
-Please ensure that the Particular ServiceControl queue is specified either via code (config.CustomChecksPlugin(servicecontrolQueue)) or AppSettings (eg. <add key=""ServiceControl/Queue"" value=""particular.servicecontrol@machine""/>).";
+Please ensure that the Particular ServiceControl queue is specified either via code (endpointConfiguration.CustomCheckPlugin(\"particular.servicecontrol@machine\")) or AppSettings (eg. <add key=""ServiceControl/Queue"" value=""particular.servicecontrol@machine""/>).";
 
             throw new Exception(errMsg);
         }

--- a/src/Shared/ServiceControlBackend.cs
+++ b/src/Shared/ServiceControlBackend.cs
@@ -104,7 +104,7 @@
             }
 
             const string errMsg = @"You have ServiceControl plugins installed in your endpoint, however, the Particular ServiceControl queue is not specified.
-Please ensure that the Particular ServiceControl queue is specified either via code (endpointConfiguration.CustomCheckPlugin(\"particular.servicecontrol@machine\")) or AppSettings (eg. <add key=""ServiceControl/Queue"" value=""particular.servicecontrol@machine""/>).";
+Please ensure that the Particular ServiceControl queue is specified either via code (endpointConfiguration.CustomCheckPlugin(""particular.servicecontrol@machine"")) or AppSettings (eg. <add key=""ServiceControl/Queue"" value=""particular.servicecontrol@machine""/>).";
 
             throw new Exception(errMsg);
         }


### PR DESCRIPTION
When the plugin starts, if the ServiceControl queue has not been configured then you get the following error message:

> You have ServiceControl plugins installed in your endpoint, however, the Particular ServiceControl queue is not specified.
Please ensure that the Particular ServiceControl queue is specified either via code (config.CustomChecksPlugin(servicecontrolQueue)) or AppSettings (eg. <add key="ServiceControl/Queue" value="particular.servicecontrol@machine"/>).

There is no `CustomChecksPlugin(...)` method on `EndpointConfiguration`. The method is named `CustomCheckPlugin(...)` with no *s*.